### PR TITLE
[FEAT] 네이버 SEO 소유확인 태그 추가

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -48,6 +48,9 @@ export default function App() {
           <Meta name="twitter:title" content="WAKULATOR" />
           <Meta name="twitter:description" content="왁큘레이터 - 왁물원 등급 계산기" />
 
+          {/* 네이버 SEO - 소유 확인 */}
+          <Meta name="naver-site-verification" content="0957a708b599810fd51e1c548629e1a4f23f71b1" />
+
           <Suspense>{props.children}</Suspense>
         </MetaProvider>
       )}


### PR DESCRIPTION
## 수정 사항
아래와 같은 기능이 수정/변경되었습니다.

* 네이버 SEO에 왁큘레이터를 노출시키기 위한 소유인증 태그를 추가합니다. 해당 태그가 삭제되면 안됩니다.

## 비고
머지 시 바로 배포됩니다. (별도 설정 필요 X)
